### PR TITLE
Default sort by changeDate

### DIFF
--- a/js/controllers/ctr-presentation-list.js
+++ b/js/controllers/ctr-presentation-list.js
@@ -8,9 +8,9 @@ angular.module('risevision.editorApp.controllers')
       $scope.presentations = new BaseList(DB_MAX_COUNT);
 
       $scope.search = {
-        sortBy: 'name',
+        sortBy: 'changeDate',
         count: DB_MAX_COUNT,
-        reverse: false
+        reverse: true
       };
 
       $scope.filterConfig = {

--- a/test/unit/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/controllers/ctr-presentation-list.tests.js
@@ -153,7 +153,7 @@ describe('controller: Presentation List', function() {
 
     describe('sortBy: ',function(){
       it('should reset list and reverse sort by changeDate',function(done){
-        $scope.sortBy('name');
+        $scope.sortBy('changeDate');
         $scope.$digest();
 
         expect($scope.loadingPresentations).to.be.true;
@@ -164,8 +164,8 @@ describe('controller: Presentation List', function() {
 
           expect($scope.presentations.list).to.have.length(40);
 
-          expect($scope.search.sortBy).to.equal('name');
-          expect($scope.search.reverse).to.be.true;
+          expect($scope.search.sortBy).to.equal('changeDate');
+          expect($scope.search.reverse).to.be.false;
 
           done();
         },10);
@@ -204,8 +204,8 @@ describe('controller: Presentation List', function() {
 
         expect($scope.presentations.list).to.have.length(40);
 
-        expect($scope.search.sortBy).to.equal('name');
-        expect($scope.search.reverse).to.be.false;
+        expect($scope.search.sortBy).to.equal('changeDate');
+        expect($scope.search.reverse).to.be.true;
 
         done();
       },10);


### PR DESCRIPTION
By default lists should be ordered by `changeDate` (similar to Displays/Schedules).

@ezequielc please review. Thanks.