### PR TITLE
Using custom window for Widget modal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "www"
   ],
   "dependencies": {
-    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.11",
+    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.14",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v1.5.3",
     "angular-ui-select2": "~0.0.5",
     "angular": "~1.3.0",
@@ -38,6 +38,7 @@
     "angular": "~1.3.0",
     "angular-mocks": "~1.3.0",
     "jquery": "~2.1.1",
-    "angular-bootstrap": "~0.13.0"
+    "angular-bootstrap": "~0.13.0",
+    "rv-common-style": "v1.3.14"
   }
 }

--- a/js/services/svc-widget-modal-factory.js
+++ b/js/services/svc-widget-modal-factory.js
@@ -30,6 +30,7 @@ angular.module('risevision.editorApp.services')
         }
 
         var modalInstance = $modal.open({
+          windowTemplateUrl: 'partials/simple-modal.html',
           templateUrl: 'partials/widget-modal.html',
           controller: 'widgetModal',
           size: 'lg',

--- a/partials/placeholder-playlist.html
+++ b/partials/placeholder-playlist.html
@@ -1,6 +1,7 @@
 <div dropdown>
   <button id="addPlaylistItemButton" dropdown-toggle class="dropdown-toggle btn btn-primary btn-block" >{{'editor-app.playlistItem.add' | translate}}  <i class="fa fa-plus icon-right"></i></button>
-  <ul class="dropdown-menu playlist-menu" role="menu">
+  <div class="dropdown-menu playlist-menu" role="menu">
+    <ul>
     <li>
       <a class="clickable" id="addContentButton" ng-click="playlistItemFactory.addContent()">
       <span translate>editor-app.playlistItem.content</span>
@@ -11,8 +12,8 @@
         <span translate>schedules-app.playlist.item.presentation</span>
       </a>
     </li>
-
-  </ul>
+    </ul>
+  </div>
 </div>
 <div class="content-box half-top">
   <div class="scrollable-list">

--- a/partials/simple-modal.html
+++ b/partials/simple-modal.html
@@ -1,0 +1,6 @@
+<div modal-render="{{$isRendered}}" tabindex="-1" role="dialog" class="modal"
+    modal-animation-class="fade"
+    modal-in-class="in"
+    ng-style="{'z-index': 1050 + index*10, display: 'block'}">
+    <div class="modal-dialog modal-full" ng-class="size ? 'modal-' + size : ''"><div modal-transclude></div></div>
+</div>


### PR DESCRIPTION
By overriding the window modal template, we can remove the extra styling around the Widget Settings.

Original window modal html for reference:
https://github.com/angular-ui/bootstrap/blob/master/template/modal/window.html

[stage-1]