### PR TITLE
New presentation from template as url param

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-   version: 0.12.2
+   version: 4.2.2
 general:
   artifacts:
     - dist.tar.gz

--- a/js/app.js
+++ b/js/app.js
@@ -79,14 +79,17 @@ angular.module('risevision.editorApp', [
         controller: 'WorkspaceController',
         resolve: {
           presentationInfo: ['canAccessEditor', 'editorFactory',
-            '$stateParams',
-            function (canAccessEditor, editorFactory, $stateParams) {
+            '$stateParams', '$location',
+            function (canAccessEditor, editorFactory, $stateParams, $location) {
               return canAccessEditor().then(function () {
-                if ($stateParams.presentationId) {
-                  //load the presentation based on the url param
+                if ($stateParams.presentationId && $stateParams.presentationId !== 'new') {
                   return editorFactory.getPresentation($stateParams
                     .presentationId);
                 } else if (!$stateParams.copyPresentation) {
+                  var copyOf = $location.search().copyOf;
+                  if (copyOf) {
+                    return editorFactory.newCopyOf(copyOf);
+                  }
                   editorFactory.openPresentationProperties();
                   return editorFactory.newPresentation();
                 } else {

--- a/js/services/svc-editor-factory.js
+++ b/js/services/svc-editor-factory.js
@@ -309,13 +309,8 @@ angular.module('risevision.editorApp.services')
         });
       };
 
-      var _addTemplate = function (productDetails) {
-        if (!productDetails || !productDetails.rvaEntityId) {
-          return;
-        }
-
-        //load template
-        factory.getPresentation(productDetails.rvaEntityId)
+      factory.newCopyOf = function(presentationId){
+        factory.getPresentation(presentationId)
           .then(factory.copyPresentation);
       };
 
@@ -331,7 +326,12 @@ angular.module('risevision.editorApp.services')
           }
         });
 
-        modalInstance.result.then(_addTemplate);
+        modalInstance.result.then(function(productDetails){
+          if (!productDetails || !productDetails.rvaEntityId) {
+            return;
+          }
+          factory.newCopyOf(productDetails.rvaEntityId);
+        });
       };
 
       factory.getPreviewUrl = function () {

--- a/test/unit/services/svc-editor-factory.tests.js
+++ b/test/unit/services/svc-editor-factory.tests.js
@@ -491,6 +491,24 @@ describe('service: editorFactory:', function() {
 
   });
 
+  it('newCopyOf: ', function(done) {
+    editorFactory.newCopyOf("presentationId");
+    
+    setTimeout(function() {
+      expect(editorFactory.loadingPresentation).to.be.false;
+
+      expect(editorFactory.presentation.id).to.not.be.ok;
+      expect(editorFactory.presentation.name).to.equal('Copy of some presentation');
+      
+      expect(trackerCalled).to.equal('Presentation Copied');
+      expect(currentState).to.equal('editor.workspace.artboard');
+      expect(stateParams).to.deep.equal({presentationId: undefined, copyPresentation:true});
+
+      done();
+    }, 10);
+
+  });
+
   it('getPreviewUrl: ', function(done) {
     expect(editorFactory.getPreviewUrl()).to.not.be.ok;
     


### PR DESCRIPTION
  - Added `templateId` param for new presentation url
  - Added `new` to new presentation url, so it looks more usual. New presentation url supports both `#/editor/workspace//` and `#/editor/workspace/new/`
  - Updated node version to fix build

@alex-deaconu Please review. Thanks